### PR TITLE
Merchant bulk discount edit user story 6

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -24,9 +24,25 @@ class BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(merchant.id)
   end
 
+  def edit
+    @merchant = Merchant.find(params[:id])
+    @bulk_discount = BulkDiscount.find(params[:bulk_discount_id])
+  end
+
+  def update
+    merchant = Merchant.find(params[:merchant_id])
+    bulk_discount = BulkDiscount.find(params[:id])
+    bulk_discount.update(update_params)
+    redirect_to merchant_bulk_discounts_path(merchant.id)
+  end
+
   private
 
   def discount_params
     params.permit(:name, :percentage, :quantity_threshold)
+  end
+
+  def update_params
+    params.require(:bulk_discount).permit(:name, :percentage, :quantity_threshold)
   end
 end

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,12 @@
+<%= form_with model: @bulk_discount, url: merchant_bulk_discount_path(@merchant, @bulk_discount.id), method: :patch, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :percentage %>
+  <%= f.number_field :percentage %>
+
+  <%= f.label :quantity_threshold, "Quantity Threshold" %>
+  <%= f.number_field :quantity_threshold  %>
+
+  <%= f.submit "Update"%>
+<% end %>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -12,8 +12,11 @@
 </div>
 
 <% @merchant.bulk_discounts.each do |discount| %>
-    <h2><%= link_to "#{discount.name}", "/merchant/#{@merchant.id}/#{discount.id}" %></h2>
-    <h3>Percentage Discount: <%= discount.percentage %>%</h3>
-    <h3>Quantity Threshold: <%= discount.quantity_threshold %></h3>
-    <%= link_to 'Delete Discount', merchant_bulk_discount_path(@merchant, discount.id),  method: :delete %>
+    <section id="discount-<%= discount.id %>">
+        <h2><%= link_to "#{discount.name}", "/merchant/#{@merchant.id}/#{discount.id}" %></h2>
+        <h3>Percentage Discount: <%= discount.percentage %>%</h3>
+        <h3>Quantity Threshold: <%= discount.quantity_threshold %></h3>
+        <%= link_to 'Edit Discount', "/merchant/#{@merchant.id}/#{discount.id}/edit" %>
+        <%= link_to 'Delete Discount', merchant_bulk_discount_path(@merchant, discount.id),  method: :delete %>
+    </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,11 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :destroy]
+    resources :bulk_discounts, only: [:index, :show, :destroy, :update]
   end
 
   get "/merchant/:id/:bulk_discount_id", to: "bulk_discounts#show"
+  get "/merchant/:id/:bulk_discount_id/edit", to: "bulk_discounts#edit"
   get "/merchant/:id/bulk_discount/new", to: "bulk_discounts#new"
   post "/merchant/:id/bulk_discount", to: "bulk_discounts#create"
 

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Bulk Discount Index Page' do
     @bulk_discount2 = @merchant1.bulk_discounts.create!(name: "Discount B", percentage: 30, quantity_threshold: 15)
     @bulk_discount3 = @merchant2.bulk_discounts.create!(name: "Discount C", percentage: 35, quantity_threshold: 25)
     @bulk_discount4 = @merchant2.bulk_discounts.create!(name: "Discount D", percentage: 10, quantity_threshold: 10)
-
+    @bulk_discount4 = @merchant2.bulk_discounts.create!(name: "Discount Z", percentage: 10, quantity_threshold: 10)
 
     @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
     @customer_2 = Customer.create!(first_name: 'Cecilia', last_name: 'Jones')
@@ -91,5 +91,28 @@ RSpec.describe 'Bulk Discount Index Page' do
     expect(page).to_not have_content(@bulk_discount.name)
     expect(page).to have_content(@bulk_discount2.name)
     expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+  end
+
+  it "has a link to edit a discount" do
+    click_on("View all Discounts")
+
+    click_on("Edit Discount", match: :first)
+
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/#{@bulk_discount.id}/edit")
+
+    fill_in "Name", with: "Discount G"
+    fill_in "Percentage", with: "22"
+    fill_in "Quantity Threshold", with: "31"
+    click_button "Update"
+
+    within("#discount-#{@bulk_discount.id}") do
+      expect(page).to_not have_content(@bulk_discount.name)
+      expect(page).to_not have_content(@bulk_discount.percentage)
+      expect(page).to_not have_content(@bulk_discount.quantity_threshold)
+      expect(page).to have_content("Discount G")
+      expect(page).to have_content("22")
+      expect(page).to have_content("31")
+      expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+    end
   end
 end


### PR DESCRIPTION
- When user visits bulk discount show page there is a link to edit the bulk discount
- When user clicks this link they are taken to a new page with a form to edit the discount
- The discounts current attributes are pre-poluated in the form
- When user changes any/all of the information and clicks submit they are redirected to the bulk discount's show page
- And see that the discount's attributes have been updated